### PR TITLE
StylesheetResolver: let Saxon resolve local xsl:import/include again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>core</artifactId>
-            <version>5.0.1</version>
+            <version>5.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <!-- new Jena ontology API (org.apache.jena.ontapi); PrefixGraphRepository extends DocumentGraphRepository -->

--- a/src/main/java/com/atomgraph/client/Application.java
+++ b/src/main/java/com/atomgraph/client/Application.java
@@ -135,7 +135,7 @@ public class Application extends ResourceConfig
         try
         {
             XsltCompiler xsltComp = xsltProc.newXsltCompiler();
-            xsltComp.setURIResolver(new StylesheetResolver(resolver.getRepository(), GraphStoreClient.create(client, mediaTypes)));
+            xsltComp.setURIResolver(new StylesheetResolver(client));
             xsltExec = xsltComp.compile(stylesheet);
         }
         catch (SaxonApiException ex)

--- a/src/main/java/com/atomgraph/client/Application.java
+++ b/src/main/java/com/atomgraph/client/Application.java
@@ -103,7 +103,6 @@ public class Application extends ResourceConfig
     {
         this(new MediaTypes(), getClient(new ClientConfig()),
             servletConfig.getServletContext().getInitParameter(A.maxGetRequestSize.getURI()) != null ? Integer.valueOf(servletConfig.getServletContext().getInitParameter(A.maxGetRequestSize.getURI())) : null,
-            servletConfig.getServletContext().getInitParameter(A.preemptiveAuth.getURI()) != null ? Boolean.parseBoolean(servletConfig.getServletContext().getInitParameter(A.preemptiveAuth.getURI())) : false,
             getResolver(servletConfig.getServletContext().getInitParameter(AC.prefixMapping.getURI()),
                 com.atomgraph.client.Application.getClient(new ClientConfig()),
                 new MediaTypes(),
@@ -114,7 +113,7 @@ public class Application extends ResourceConfig
         );
     }
     
-    public Application(final MediaTypes mediaTypes, final Client client, final Integer maxGetRequestSize, final boolean preemptiveAuth,
+    public Application(final MediaTypes mediaTypes, final Client client, final Integer maxGetRequestSize,
             final RDFSourceResolver resolver, final Source stylesheet, final boolean cacheStylesheet, final boolean resolvingUncached)
     {
         this.mediaTypes = mediaTypes;

--- a/src/main/java/com/atomgraph/client/util/StylesheetResolver.java
+++ b/src/main/java/com/atomgraph/client/util/StylesheetResolver.java
@@ -28,23 +28,20 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamSource;
 import org.apache.commons.io.IOUtils;
-import org.apache.jena.atlas.web.TypedInputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Resolves XSLT {@code xsl:import}/{@code xsl:include} URIs to raw stylesheet {@link Source}s
- * during compilation. Mapped/classpath/file locations are opened via the repository's RIOT stream
- * manager; HTTP via the {@link GraphStoreClient}. Unlike {@link RDFSourceResolver} the bytes are
- * returned verbatim (stylesheets are XML, not RDF). Replaces the legacy {@code XsltResolver}
- * (which extended the FileManager-based {@code DataManagerImpl}).
+ * during compilation. HTTP locations are fetched via the {@link GraphStoreClient}; local
+ * ({@code file:}/{@code jar:}/classpath) locations are handed back to Saxon by returning
+ * {@code null}, so its default resolver opens them (relative imports against a {@code file:}/{@code jar:}
+ * base need no location mapping). Unlike {@link RDFSourceResolver} the bytes are returned verbatim
+ * (stylesheets are XML, not RDF). Replaces the legacy {@code XsltResolver} (which extended the
+ * FileManager-based {@code DataManagerImpl}).
  *
  * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
  */
 public class StylesheetResolver implements URIResolver
 {
-
-    private static final Logger log = LoggerFactory.getLogger(StylesheetResolver.class);
 
     private final PrefixGraphRepository repository;
     private final GraphStoreClient gsc;
@@ -52,7 +49,7 @@ public class StylesheetResolver implements URIResolver
     /**
      * Constructs the resolver.
      *
-     * @param repository graph repository for URI→location mapping and classpath/file opening
+     * @param repository graph repository for URI→location mapping
      * @param gsc Graph Store client for HTTP retrieval
      */
     public StylesheetResolver(PrefixGraphRepository repository, GraphStoreClient gsc)
@@ -80,13 +77,7 @@ public class StylesheetResolver implements URIResolver
                 }
             }
 
-            TypedInputStream in = getRepository().getStreamManager().open(location);
-            if (in == null)
-            {
-                if (log.isWarnEnabled()) log.warn("Could not resolve stylesheet location: {}", location);
-                return null;
-            }
-            return new StreamSource(in, uri.toString());
+            return null; // non-HTTP (file:/jar:/classpath): let Saxon's default resolver open it
         }
         catch (IOException ex)
         {

--- a/src/main/java/com/atomgraph/client/util/StylesheetResolver.java
+++ b/src/main/java/com/atomgraph/client/util/StylesheetResolver.java
@@ -16,8 +16,8 @@
  */
 package com.atomgraph.client.util;
 
-import com.atomgraph.core.client.GraphStoreClient;
-import com.atomgraph.client.util.jena.PrefixGraphRepository;
+import com.atomgraph.client.MediaType;
+import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -31,31 +31,27 @@ import org.apache.commons.io.IOUtils;
 
 /**
  * Resolves XSLT {@code xsl:import}/{@code xsl:include} URIs to raw stylesheet {@link Source}s
- * during compilation. HTTP locations are fetched via the {@link GraphStoreClient}; local
- * ({@code file:}/{@code jar:}/classpath) locations are handed back to Saxon by returning
- * {@code null}, so its default resolver opens them (relative imports against a {@code file:}/{@code jar:}
- * base need no location mapping). Unlike {@link RDFSourceResolver} the bytes are returned verbatim
- * (stylesheets are XML, not RDF). Replaces the legacy {@code XsltResolver} (which extended the
- * FileManager-based {@code DataManagerImpl}).
+ * during compilation. HTTP(S) locations are fetched with the SSL-configured JAX-RS {@link Client}
+ * (app stylesheets served over HTTPS need its trust store / client certificate), requesting
+ * {@code text/xsl}; local ({@code file:}/{@code jar:}/classpath) locations are handed back to Saxon
+ * by returning {@code null}, so its default resolver opens them. Bytes are returned verbatim
+ * (stylesheets are XML, not RDF).
  *
  * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
  */
 public class StylesheetResolver implements URIResolver
 {
 
-    private final PrefixGraphRepository repository;
-    private final GraphStoreClient gsc;
+    private final Client client;
 
     /**
      * Constructs the resolver.
      *
-     * @param repository graph repository for URI→location mapping
-     * @param gsc Graph Store client for HTTP retrieval
+     * @param client SSL-configured JAX-RS client for HTTP(S) stylesheet retrieval
      */
-    public StylesheetResolver(PrefixGraphRepository repository, GraphStoreClient gsc)
+    public StylesheetResolver(Client client)
     {
-        this.repository = repository;
-        this.gsc = gsc;
+        this.client = client;
     }
 
     @Override
@@ -63,21 +59,21 @@ public class StylesheetResolver implements URIResolver
     {
         URI baseURI = URI.create(base);
         URI uri = href.isEmpty() ? baseURI : baseURI.resolve(href);
-        String location = getRepository().resolve(uri.toString());
 
-        try
-        {
-            if (location.startsWith("http://") || location.startsWith("https://"))
-            {
-                try (Response cr = getGraphStoreClient().getClient().target(URI.create(location)).request().get();
-                     InputStream is = cr.readEntity(InputStream.class))
-                {
-                    byte[] bytes = IOUtils.toByteArray(is); // buffer so we can close the Response
-                    return new StreamSource(new ByteArrayInputStream(bytes), uri.toString());
-                }
-            }
-
+        if (!"http".equals(uri.getScheme()) && !"https".equals(uri.getScheme()))
             return null; // non-HTTP (file:/jar:/classpath): let Saxon's default resolver open it
+
+        try (Response cr = getClient().target(uri).request().accept(MediaType.TEXT_XSL_TYPE).get())
+        {
+            if (!cr.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL))
+                throw new IOException("XSLT stylesheet could not be loaded over HTTP. Status: " + cr.getStatus() + ", URI: " + uri);
+
+            // buffer the stylesheet stream so we can close the Response
+            try (InputStream is = cr.readEntity(InputStream.class))
+            {
+                byte[] bytes = IOUtils.toByteArray(is);
+                return new StreamSource(new ByteArrayInputStream(bytes), uri.toString());
+            }
         }
         catch (IOException ex)
         {
@@ -86,23 +82,13 @@ public class StylesheetResolver implements URIResolver
     }
 
     /**
-     * Returns the graph repository.
-     *
-     * @return repository
-     */
-    public PrefixGraphRepository getRepository()
-    {
-        return repository;
-    }
-
-    /**
-     * Returns the Graph Store client.
+     * Returns the JAX-RS client used for HTTP(S) retrieval.
      *
      * @return client
      */
-    public GraphStoreClient getGraphStoreClient()
+    public Client getClient()
     {
-        return gsc;
+        return client;
     }
 
 }

--- a/src/main/java/com/atomgraph/client/util/jena/PrefixGraphRepository.java
+++ b/src/main/java/com/atomgraph/client/util/jena/PrefixGraphRepository.java
@@ -20,6 +20,7 @@ import com.atomgraph.core.client.GraphStoreClient;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.ontapi.impl.repositories.DocumentGraphRepository;
 import org.apache.jena.rdf.model.Model;
@@ -45,6 +46,9 @@ import org.slf4j.LoggerFactory;
  * the ontology {@code ModelGetter} used for {@code owl:imports} resolution. HTTP/HTTPS locations
  * are loaded via the {@link GraphStoreClient}; other locations (classpath, file) via a RIOT
  * {@link StreamManager}. Loaded graphs are cached by ID in the inherited repository store.
+ *
+ * The repository is shared across request threads while the inherited store is an unsynchronized
+ * map, so all store access is synchronized here; loading itself happens outside the lock.
  *
  * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
  */
@@ -182,7 +186,7 @@ public class PrefixGraphRepository extends DocumentGraphRepository
      * @param id graph ID
      * @return true if cached
      */
-    public boolean isCached(String id)
+    public synchronized boolean isCached(String id)
     {
         return getIds().contains(id);
     }
@@ -190,13 +194,63 @@ public class PrefixGraphRepository extends DocumentGraphRepository
     @Override
     public Graph get(String id)
     {
-        if (getIds().contains(id)) return super.get(id); // already loaded into the store
+        synchronized (this)
+        {
+            if (getIds().contains(id)) return super.get(id); // already loaded into the store
+        }
 
         String location = resolve(id);
         if (log.isDebugEnabled()) log.debug("Loading graph '{}' from location '{}'", id, location);
-        Graph graph = load(id, location);
-        put(id, graph);
-        return graph;
+        Graph graph = load(id, location); // I/O outside the lock — concurrent first loads may duplicate work
+
+        synchronized (this)
+        {
+            if (getIds().contains(id)) return super.get(id); // lost the race — another thread loaded it first
+            put(id, graph);
+            return graph;
+        }
+    }
+
+    @Override
+    public synchronized Graph put(String id, Graph graph)
+    {
+        return super.put(id, graph);
+    }
+
+    @Override
+    public synchronized Graph remove(String id)
+    {
+        return super.remove(id);
+    }
+
+    @Override
+    public synchronized void clear()
+    {
+        super.clear();
+    }
+
+    @Override
+    public synchronized boolean contains(String id)
+    {
+        return super.contains(id);
+    }
+
+    @Override
+    public synchronized long count()
+    {
+        return super.count();
+    }
+
+    @Override
+    public synchronized Stream<String> ids()
+    {
+        return super.ids().toList().stream(); // snapshot under the lock — a live stream would read the store unsynchronized
+    }
+
+    @Override
+    public synchronized Stream<Graph> loadedGraphs()
+    {
+        return super.loadedGraphs().toList().stream(); // snapshot under the lock — a live stream would read the store unsynchronized
     }
 
     /**

--- a/src/main/java/com/atomgraph/client/util/jena/PrefixGraphRepository.java
+++ b/src/main/java/com/atomgraph/client/util/jena/PrefixGraphRepository.java
@@ -17,8 +17,10 @@
 package com.atomgraph.client.util.jena;
 
 import com.atomgraph.core.client.GraphStoreClient;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.jena.graph.Graph;
@@ -45,10 +47,11 @@ import org.slf4j.LoggerFactory;
  * caching), the {@code PrefixMapper} ({@code LocationMapper} subclass with prefix matching), and
  * the ontology {@code ModelGetter} used for {@code owl:imports} resolution. HTTP/HTTPS locations
  * are loaded via the {@link GraphStoreClient}; other locations (classpath, file) via a RIOT
- * {@link StreamManager}. Loaded graphs are cached by ID in the inherited repository store.
+ * {@link StreamManager}. Dynamically loaded graphs are cached by ID in a store obtained from
+ * {@link #createStore()} (overridable, e.g. to supply a bounded/evicting map).
  *
- * The repository is shared across request threads while the inherited store is an unsynchronized
- * map, so all store access is synchronized here; loading itself happens outside the lock.
+ * The repository is shared across request threads while the store is a plain unsynchronized map, so
+ * all store access is synchronized here; loading itself happens outside the lock.
  *
  * Bundled (non-HTTP mapped) documents are cached by their resolved location rather than by graph
  * ID, so that every URI in a mapped namespace shares a single graph. This bounds the cache to the
@@ -65,9 +68,23 @@ public class PrefixGraphRepository extends DocumentGraphRepository
 
     private final Map<String, String> exactLocations = new HashMap<>();
     private final Map<String, String> prefixLocations = new HashMap<>();
+    private final Map<String, Graph> store = createStore(); // dynamically loaded graphs, keyed by graph ID
     private final Map<String, Graph> mappedGraphs = new HashMap<>(); // bundled documents cached by resolved location, shared across all URIs in the namespace
     private final GraphStoreClient gsc;
     private final StreamManager streamManager;
+
+    /**
+     * Creates the backing store for dynamically loaded graphs (keyed by graph ID). The default is an
+     * unbounded {@link HashMap}; subclasses may override to supply a bounded/evicting map. The returned
+     * map must not depend on subclass state — it is created during construction. The location-keyed
+     * bundled-document cache is separate and always unbounded (bounded by the number of bundled files).
+     *
+     * @return dynamic-graph store
+     */
+    protected Map<String, Graph> createStore()
+    {
+        return new HashMap<>();
+    }
 
     /**
      * Constructs the repository with the Graph Store client used for HTTP loading.
@@ -217,7 +234,7 @@ public class PrefixGraphRepository extends DocumentGraphRepository
      */
     public synchronized boolean isCached(String id)
     {
-        return getIds().contains(id) || mappedGraphs.containsKey(resolve(id));
+        return store.containsKey(id) || mappedGraphs.containsKey(resolve(id));
     }
 
     @Override
@@ -226,7 +243,8 @@ public class PrefixGraphRepository extends DocumentGraphRepository
         String location;
         synchronized (this)
         {
-            if (getIds().contains(id)) return super.get(id); // explicitly cached (e.g. a materialized ontology) or non-mapped
+            Graph cached = store.get(id); // explicitly cached (e.g. a materialized ontology) or non-mapped
+            if (cached != null) return cached;
             location = resolve(id);
             Graph mapped = mappedGraphs.get(location);
             if (mapped != null) return mapped; // bundled document already loaded — shared across the namespace
@@ -243,8 +261,9 @@ public class PrefixGraphRepository extends DocumentGraphRepository
         {
             if (mapped) return mappedGraphs.computeIfAbsent(location, k -> graph); // loser of a race discards its graph
 
-            if (getIds().contains(id)) return super.get(id);
-            put(id, graph);
+            Graph raced = store.get(id);
+            if (raced != null) return raced; // lost the race — another thread loaded it first
+            store.put(id, graph);
             return graph;
         }
     }
@@ -252,13 +271,13 @@ public class PrefixGraphRepository extends DocumentGraphRepository
     @Override
     public synchronized Graph put(String id, Graph graph)
     {
-        return super.put(id, graph);
+        return store.put(id, graph);
     }
 
     @Override
     public synchronized Graph remove(String id)
     {
-        Graph removed = super.remove(id);
+        Graph removed = store.remove(id);
         Graph mapped = mappedGraphs.remove(resolve(id));
         return removed != null ? removed : mapped;
     }
@@ -266,32 +285,34 @@ public class PrefixGraphRepository extends DocumentGraphRepository
     @Override
     public synchronized void clear()
     {
-        super.clear();
+        store.clear();
         mappedGraphs.clear();
     }
 
     @Override
     public synchronized boolean contains(String id)
     {
-        return super.contains(id) || mappedGraphs.containsKey(resolve(id));
+        return store.containsKey(id) || mappedGraphs.containsKey(resolve(id));
     }
 
     @Override
     public synchronized long count()
     {
-        return super.count() + mappedGraphs.size();
+        return store.size() + mappedGraphs.size();
     }
 
     @Override
     public synchronized Stream<String> ids()
     {
-        return super.ids().toList().stream(); // snapshot under the lock — a live stream would read the store unsynchronized
+        return List.copyOf(store.keySet()).stream(); // snapshot under the lock — a live stream would read the store unsynchronized
     }
 
     @Override
     public synchronized Stream<Graph> loadedGraphs()
     {
-        return super.loadedGraphs().toList().stream(); // snapshot under the lock — a live stream would read the store unsynchronized
+        List<Graph> loaded = new ArrayList<>(store.values());
+        loaded.addAll(mappedGraphs.values());
+        return loaded.stream(); // snapshot under the lock — a live stream would read the store unsynchronized
     }
 
     /**

--- a/src/main/java/com/atomgraph/client/util/jena/PrefixGraphRepository.java
+++ b/src/main/java/com/atomgraph/client/util/jena/PrefixGraphRepository.java
@@ -50,6 +50,12 @@ import org.slf4j.LoggerFactory;
  * The repository is shared across request threads while the inherited store is an unsynchronized
  * map, so all store access is synchronized here; loading itself happens outside the lock.
  *
+ * Bundled (non-HTTP mapped) documents are cached by their resolved location rather than by graph
+ * ID, so that every URI in a mapped namespace shares a single graph. This bounds the cache to the
+ * number of bundled files regardless of how many distinct URIs are requested — otherwise an actor
+ * minting distinct URIs under a mapped prefix (e.g. {@code http://xmlns.com/foaf/0.1/<n>}) would
+ * grow the store without bound.
+ *
  * @author Martynas Jusevičius {@literal <martynas@atomgraph.com>}
  */
 public class PrefixGraphRepository extends DocumentGraphRepository
@@ -59,6 +65,7 @@ public class PrefixGraphRepository extends DocumentGraphRepository
 
     private final Map<String, String> exactLocations = new HashMap<>();
     private final Map<String, String> prefixLocations = new HashMap<>();
+    private final Map<String, Graph> mappedGraphs = new HashMap<>(); // bundled documents cached by resolved location, shared across all URIs in the namespace
     private final GraphStoreClient gsc;
     private final StreamManager streamManager;
 
@@ -141,11 +148,33 @@ public class PrefixGraphRepository extends DocumentGraphRepository
         for (Iterator<String> it = prefixLocations.keySet().iterator(); it.hasNext();)
         {
             String candidate = it.next();
-            if (id.startsWith(candidate) && (prefix == null || candidate.length() > prefix.length())) prefix = candidate;
+            if (matchesPrefix(id, candidate) && (prefix == null || candidate.length() > prefix.length())) prefix = candidate;
         }
         if (prefix != null) return prefixLocations.get(prefix);
 
         return id;
+    }
+
+    /**
+     * Returns true if the id falls under the namespace prefix at a URI boundary: the id equals the
+     * prefix, the prefix already ends at a delimiter, or the character following the prefix in the id
+     * is a {@code /} or {@code #}. Prevents an unrelated URI (e.g. {@code …/foobar}) from matching a
+     * shorter prefix (e.g. {@code …/foo}) and resolving to the wrong mapped location.
+     *
+     * @param id graph ID
+     * @param prefix candidate namespace prefix
+     * @return true if the id is within the prefix namespace
+     */
+    protected static boolean matchesPrefix(String id, String prefix)
+    {
+        if (!id.startsWith(prefix)) return false;
+        if (id.length() == prefix.length()) return true;
+
+        char last = prefix.charAt(prefix.length() - 1);
+        if (last == '/' || last == '#') return true;
+
+        char next = id.charAt(prefix.length());
+        return next == '/' || next == '#';
     }
 
     /**
@@ -188,24 +217,33 @@ public class PrefixGraphRepository extends DocumentGraphRepository
      */
     public synchronized boolean isCached(String id)
     {
-        return getIds().contains(id);
+        return getIds().contains(id) || mappedGraphs.containsKey(resolve(id));
     }
 
     @Override
     public Graph get(String id)
     {
+        String location;
         synchronized (this)
         {
-            if (getIds().contains(id)) return super.get(id); // already loaded into the store
+            if (getIds().contains(id)) return super.get(id); // explicitly cached (e.g. a materialized ontology) or non-mapped
+            location = resolve(id);
+            Graph mapped = mappedGraphs.get(location);
+            if (mapped != null) return mapped; // bundled document already loaded — shared across the namespace
         }
 
-        String location = resolve(id);
         if (log.isDebugEnabled()) log.debug("Loading graph '{}' from location '{}'", id, location);
         Graph graph = load(id, location); // I/O outside the lock — concurrent first loads may duplicate work
 
+        // bundled (non-HTTP mapped) documents are cached by location so every URI in the namespace shares one
+        // graph, bounding the store; everything else (HTTP, identity) is cached by ID
+        boolean mapped = !location.equals(id) && !location.startsWith("http://") && !location.startsWith("https://");
+
         synchronized (this)
         {
-            if (getIds().contains(id)) return super.get(id); // lost the race — another thread loaded it first
+            if (mapped) return mappedGraphs.computeIfAbsent(location, k -> graph); // loser of a race discards its graph
+
+            if (getIds().contains(id)) return super.get(id);
             put(id, graph);
             return graph;
         }
@@ -220,25 +258,28 @@ public class PrefixGraphRepository extends DocumentGraphRepository
     @Override
     public synchronized Graph remove(String id)
     {
-        return super.remove(id);
+        Graph removed = super.remove(id);
+        Graph mapped = mappedGraphs.remove(resolve(id));
+        return removed != null ? removed : mapped;
     }
 
     @Override
     public synchronized void clear()
     {
         super.clear();
+        mappedGraphs.clear();
     }
 
     @Override
     public synchronized boolean contains(String id)
     {
-        return super.contains(id);
+        return super.contains(id) || mappedGraphs.containsKey(resolve(id));
     }
 
     @Override
     public synchronized long count()
     {
-        return super.count();
+        return super.count() + mappedGraphs.size();
     }
 
     @Override

--- a/src/main/java/com/atomgraph/client/writer/function/ConstructForClass.java
+++ b/src/main/java/com/atomgraph/client/writer/function/ConstructForClass.java
@@ -39,6 +39,8 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.RDFWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <code>ac:construct()</code> XSLT function that constructs instances for given classes from their constructors.
@@ -49,7 +51,9 @@ import org.apache.jena.riot.RDFWriter;
  */
 public class ConstructForClass implements ExtensionFunction
 {
-    
+
+    private static final Logger log = LoggerFactory.getLogger(ConstructForClass.class);
+
     private final Processor processor;
     private final PrefixGraphRepository repository;
 
@@ -91,13 +95,20 @@ public class ConstructForClass implements ExtensionFunction
             String base = arguments[2].itemAt(0).getStringValue();
             
             Model instances = ModelFactory.createDefaultModel();
-            OntModel ontModel = OntModelFactory.createModel(getRepository().get(ontology), OntSpecification.OWL2_FULL_MEM, getRepository());
+            try
+            {
+                OntModel ontModel = OntModelFactory.createModel(getRepository().get(ontology), OntSpecification.OWL2_FULL_MEM, getRepository());
 
-            arguments[1].stream().
-                <OntClass>map(forClass -> ontModel.getOntClass(checkURI(forClass.getStringValue()).toString())).
-                filter(forClass -> forClass != null).
-                forEach(forClass -> new Constructor().construct(forClass, instances, base));
-            
+                arguments[1].stream().
+                    <OntClass>map(forClass -> ontModel.getOntClass(checkURI(forClass.getStringValue()).toString())).
+                    filter(forClass -> forClass != null).
+                    forEach(forClass -> new Constructor().construct(forClass, instances, base));
+            }
+            catch (RuntimeException ex) // ontology or one of its imports could not be loaded — return empty result instead of failing the transform
+            {
+                if (log.isWarnEnabled()) log.warn("Could not construct instances for ontology '{}': {}", ontology, ex.toString());
+            }
+
             return getProcessor().newDocumentBuilder().build(getSource(instances));
         }
         catch (IOException ex)

--- a/src/test/java/com/atomgraph/client/util/jena/PrefixGraphRepositoryTest.java
+++ b/src/test/java/com/atomgraph/client/util/jena/PrefixGraphRepositoryTest.java
@@ -16,6 +16,7 @@
  */
 package com.atomgraph.client.util.jena;
 
+import org.apache.jena.graph.Graph;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -94,6 +95,40 @@ public class PrefixGraphRepositoryTest
 
         assertEquals("file:exact.ttl", repo.resolve("http://example.org/exact#"));
         assertEquals("file:prefix.ttl", repo.resolve("http://example.org/prefix/Term"));
+    }
+
+    /**
+     * A prefix only matches at a namespace boundary — the id equals the prefix, or the character
+     * after the prefix is a {@code /} or {@code #}. An unrelated URI that merely shares the prefix
+     * string (e.g. {@code …/ns-evil}) must not resolve to the mapped location.
+     */
+    @Test
+    public void testResolveRespectsPrefixBoundary()
+    {
+        repo.addPrefixMapping("http://example.org/ns", "file:ns.ttl"); // no trailing delimiter
+
+        assertEquals("file:ns.ttl", repo.resolve("http://example.org/ns"), "exact namespace root");
+        assertEquals("file:ns.ttl", repo.resolve("http://example.org/ns#Term"), "hash boundary");
+        assertEquals("file:ns.ttl", repo.resolve("http://example.org/ns/Term"), "slash boundary");
+        assertEquals("http://example.org/nsEvil", repo.resolve("http://example.org/nsEvil"), "no boundary — must not match");
+        assertEquals("http://example.org/ns-evil", repo.resolve("http://example.org/ns-evil"), "no boundary — must not match");
+    }
+
+    /**
+     * A malicious actor minting an unbounded number of distinct URIs under a mapped prefix must not
+     * grow the cache: every URI in a mapped namespace resolves to the same bundled document, so they
+     * share one graph instance and the store stays bounded by the number of bundled files.
+     */
+    @Test
+    public void testMappedGraphCacheDoesNotGrowWithDistinctURIs()
+    {
+        repo.addPrefixMapping("http://example.org/ns/", "com/atomgraph/client/test/mint-ontology.ttl");
+
+        Graph first = repo.get("http://example.org/ns/term0");
+        for (int i = 1; i < 1000; i++)
+            assertSame(first, repo.get("http://example.org/ns/term" + i), "all URIs in a mapped namespace must share one graph instance");
+
+        assertEquals(1, repo.count(), "1000 distinct mapped URIs must not grow the cache beyond the single bundled document");
     }
 
 }

--- a/src/test/resources/com/atomgraph/client/test/mint-ontology.ttl
+++ b/src/test/resources/com/atomgraph/client/test/mint-ontology.ttl
@@ -1,0 +1,8 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@base <http://example.org/ns> .
+
+<> a owl:Ontology .
+
+<#Thing> a owl:Class ;
+    rdfs:label "Thing" .


### PR DESCRIPTION
Return null for non-HTTP locations so Saxon's default resolver opens file:/jar:/classpath stylesheet imports directly, instead of routing them through the RIOT StreamManager. All stylesheet imports are relative and resolve against a file:/jar: base with no location mapping, so the StreamManager hop added nothing but debug noise. HTTP imports still go through the GraphStoreClient; the repository is still used for URI->location mapping. Drops the now-unused logger and TypedInputStream.