### PR TITLE
Mark the language of every value a page renders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>core</artifactId>
-            <version>5.0.3-SNAPSHOT</version>
+            <version>5.0.3</version>
         </dependency>
         <dependency>
             <!-- new Jena ontology API (org.apache.jena.ontapi); PrefixGraphRepository extends DocumentGraphRepository -->

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>core</artifactId>
-            <version>5.0.2</version>
+            <version>5.0.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <!-- new Jena ontology API (org.apache.jena.ontapi); PrefixGraphRepository extends DocumentGraphRepository -->
@@ -174,7 +174,6 @@
                 <configuration>
                     <publishingServerId>central-portal-snapshots</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/atomgraph/client/vocabulary/AC.java
+++ b/src/main/java/com/atomgraph/client/vocabulary/AC.java
@@ -94,6 +94,9 @@ public final class AC
 
     public static final Property langs = m_model.createDataProperty( NS + "langs" );
 
+    /** The language the representation is composed in, as opposed to the languages the reader accepts. */
+    public static final Property contentLang = m_model.createDataProperty( NS + "contentLang" );
+
     public static final Property forClass = m_model.createObjectProperty( NS + "forClass" );
 
     public static final Property instance = m_model.createDataProperty( NS + "instance" );

--- a/src/main/java/com/atomgraph/client/vocabulary/LDT.java
+++ b/src/main/java/com/atomgraph/client/vocabulary/LDT.java
@@ -86,8 +86,6 @@ public final class LDT
 
     public static final Property cacheControl = m_model.createDataProperty( NS + "cacheControl" );
     
-    public static final Property lang = m_model.createObjectProperty( NS + "lang" );
-    
     public static final Property template = m_model.createObjectProperty( NS + "template" );
     
 }

--- a/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/container.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/container.xsl
@@ -79,7 +79,7 @@ exclude-result-prefixes="#all">
 
         <xsl:variable name="prelim-items" as="item()*">
             <xsl:apply-templates mode="#current">
-                <xsl:sort select="ac:label(.)" order="ascending" lang="{$ac:lang}"/>
+                <xsl:sort select="ac:label(.)" order="ascending" lang="{ac:langs()[1]}"/>
                 <xsl:with-param name="thumbnails-per-row" select="$thumbnails-per-row" tunnel="yes"/>
             </xsl:apply-templates>
         </xsl:variable>
@@ -133,7 +133,7 @@ exclude-result-prefixes="#all">
         <xsl:param name="class" select="'table table-bordered table-striped'" as="xs:string?"/>
         <xsl:param name="predicates" as="element()*">
             <xsl:for-each-group select="*/*" group-by="concat(namespace-uri(), local-name())">
-                <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
+                <xsl:sort select="ac:property-label(.)" order="ascending" lang="{ac:langs()[1]}"/>
 
                 <xsl:sequence select="current-group()[1]"/>
             </xsl:for-each-group>

--- a/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/imports/default.xsl
@@ -48,12 +48,18 @@ exclude-result-prefixes="#all">
     
     <xsl:template match="text()[../@xml:lang]" mode="xhtml:DefinitionDescription" priority="1">
         <dd>
-            <span class="label label-info pull-right">
-                <xsl:value-of select="../@xml:lang"/>
-            </span>
+            <xsl:apply-templates select="../@xml:lang" mode="ac:lang-tag"/>
 
             <xsl:apply-templates select="."/>
         </dd>
+    </xsl:template>
+
+    <!-- the property list and the table cell both put a value's languages side by side, so the badge that tells them
+         apart is written once here and applied from wherever the values are laid out -->
+    <xsl:template match="@xml:lang" mode="ac:lang-tag">
+        <span class="label label-info pull-right">
+            <xsl:value-of select="."/>
+        </span>
     </xsl:template>
     
     <xsl:template match="*[@rdf:about or @rdf:nodeID]/*" mode="bs2:PropertyList">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/layout.xsl
@@ -67,7 +67,20 @@ exclude-result-prefixes="#all">
     <xsl:param name="ldt:ontology" as="xs:anyURI?"/>
     <xsl:param name="rdf:type" as="xs:anyURI?"/>
     <xsl:param name="ac:googleMapsKey" select="'AIzaSyCQ4rt3EnNCmGTpBN0qoZM1Z_jXhUnrTpQ'" as="xs:string"/>
-    
+    <!-- ordered language preference list; the writer passes Accept-Language, client-side stylesheets override with the browser's list -->
+    <xsl:param name="ac:langs" select="'en'" as="xs:string*"/>
+    <xsl:param name="ac:lang" select="($ac:langs[1], 'en')[1]" as="xs:string"/>
+    <!-- the language the representation is composed in, as opposed to the one the reader asked for: the writer supplies the
+         highest-ranked accepted language the UI actually has. Distinct from $ac:lang because asking for a language does not
+         make the page that language - reporting the request as the content's language is what put lang="de" on a page written
+         entirely in English.
+
+         Defaults to en rather than to $ac:lang. The rule is "the first accepted language the UI provides, else en", and
+         Web-Client's own strings are English only, so for a client that supplies no value the negotiation would always answer
+         en whatever the reader asked for. Defaulting to $ac:lang would return a value the negotiation cannot produce - and
+         would keep the defect as the out-of-the-box behaviour -->
+    <xsl:param name="ac:contentLang" select="'en'" as="xs:string"/>
+
     <xsl:variable name="main-doc" select="/" as="document-node()"/>
     
     <xsl:key name="resources" match="*[*][@rdf:about] | *[*][@rdf:nodeID]" use="@rdf:about | @rdf:nodeID"/>
@@ -99,7 +112,7 @@ exclude-result-prefixes="#all">
     </rdf:Description>
 
     <xsl:template match="/">
-        <html lang="{$ac:lang}">
+        <html lang="{$ac:contentLang}">
             <xsl:apply-templates/>
         </html>
     </xsl:template>

--- a/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/layout.xsl
@@ -69,15 +69,14 @@ exclude-result-prefixes="#all">
     <xsl:param name="ac:googleMapsKey" select="'AIzaSyCQ4rt3EnNCmGTpBN0qoZM1Z_jXhUnrTpQ'" as="xs:string"/>
     <!-- ordered language preference list; the writer passes Accept-Language, client-side stylesheets override with the browser's list -->
     <xsl:param name="ac:langs" select="'en'" as="xs:string*"/>
-    <xsl:param name="ac:lang" select="($ac:langs[1], 'en')[1]" as="xs:string"/>
     <!-- the language the representation is composed in, as opposed to the one the reader asked for: the writer supplies the
-         highest-ranked accepted language the UI actually has. Distinct from $ac:lang because asking for a language does not
-         make the page that language - reporting the request as the content's language is what put lang="de" on a page written
-         entirely in English.
+         highest-ranked accepted language the UI actually has. Distinct from what the reader accepts because asking for a
+         language does not make the page that language - reporting the request as the content's language is what put
+         lang="de" on a page written entirely in English.
 
-         Defaults to en rather than to $ac:lang. The rule is "the first accepted language the UI provides, else en", and
+         Defaults to en rather than to the reader's top preference. The rule is "the first accepted language the UI provides, else en", and
          Web-Client's own strings are English only, so for a client that supplies no value the negotiation would always answer
-         en whatever the reader asked for. Defaulting to $ac:lang would return a value the negotiation cannot produce - and
+         en whatever the reader asked for. Defaulting to their preference would return a value the negotiation cannot produce - and
          would keep the defect as the out-of-the-box behaviour -->
     <xsl:param name="ac:contentLang" select="'en'" as="xs:string"/>
 
@@ -282,7 +281,7 @@ exclude-result-prefixes="#all">
         <div class="footer text-center">
             <hr/>
             <p>
-                <xsl:sequence select="format-date(current-date(), '[Y]', $ac:lang, (), ())"/>.
+                <xsl:sequence select="format-date(current-date(), '[Y]', ac:langs()[1], (), ())"/>.
                 Developed by <xsl:apply-templates select="key('resources', key('resources', '', document(''))/foaf:maker/@rdf:resource, document(''))/@rdf:about" mode="xhtml:Anchor"/>.
                 <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License</a>.
             </p>

--- a/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/layout.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/layout.xsl
@@ -65,7 +65,6 @@ exclude-result-prefixes="#all">
     <xsl:param name="ac:mode" select="xs:anyURI('&ac;ReadMode')" as="xs:anyURI*"/>
     <xsl:param name="ac:query" as="xs:string?"/>
     <xsl:param name="ldt:ontology" as="xs:anyURI?"/>
-    <xsl:param name="rdf:type" as="xs:anyURI?"/>
     <xsl:param name="ac:googleMapsKey" select="'AIzaSyCQ4rt3EnNCmGTpBN0qoZM1Z_jXhUnrTpQ'" as="xs:string"/>
     <!-- ordered language preference list; the writer passes Accept-Language, client-side stylesheets override with the browser's list -->
     <xsl:param name="ac:langs" select="'en'" as="xs:string*"/>

--- a/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/resource.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/bootstrap/2.3.2/resource.xsl
@@ -217,7 +217,7 @@ exclude-result-prefixes="#all">
     <xsl:template match="*[@rdf:about or @rdf:nodeID][rdf:type/@rdf:resource]" mode="bs2:TypeList" priority="1">
         <ul class="inline">
             <xsl:for-each select="rdf:type/@rdf:resource">
-                <xsl:sort select="ac:object-label(.)" order="ascending" lang="{$ac:lang}"/>
+                <xsl:sort select="ac:object-label(.)" order="ascending" lang="{ac:langs()[1]}"/>
                 
                 <li>
                     <xsl:apply-templates select="."/>
@@ -235,8 +235,8 @@ exclude-result-prefixes="#all">
             <xsl:document>
                 <dl class="dl-horizontal">
                     <xsl:apply-templates select="*" mode="#current">
-                        <xsl:sort select="ac:property-label(.)" order="ascending" lang="{$ac:lang}"/>
-                        <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1]) else()" order="ascending" lang="{$ac:lang}"/>
+                        <xsl:sort select="ac:property-label(.)" order="ascending" lang="{ac:langs()[1]}"/>
+                        <xsl:sort select="if (exists((text(), @rdf:resource, @rdf:nodeID))) then ac:object-label((text(), @rdf:resource, @rdf:nodeID)[1]) else()" order="ascending" lang="{ac:langs()[1]}"/>
                     </xsl:apply-templates>
                 </dl>
             </xsl:document>

--- a/src/main/webapp/static/com/atomgraph/client/xsl/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/functions.xsl
@@ -89,6 +89,16 @@ exclude-result-prefixes="#all"
         </xsl:message>
     </xsl:function>
     
+    <!-- position of a value's language in $ac:langs, used as a sort key so each property leads with the reader's language.
+         Values in a language the reader does not accept, and untagged values, rank last and so sort after the accepted ones
+         - they are ordered, never withheld. Takes the node explicitly: the one-argument fn:lang tests the context item, and
+         a rank computed over a range of integers has no node to test. -->
+    <xsl:function name="ac:lang-rank" as="xs:integer">
+        <xsl:param name="value" as="element()"/>
+
+        <xsl:sequence select="((for $i in 1 to count($ac:langs) return if (lang($ac:langs[$i], $value)) then $i else ())[1], count($ac:langs) + 1)[1]"/>
+    </xsl:function>
+
     <xsl:function name="ac:label" as="xs:string?">
         <xsl:param name="resource" as="element()"/>
 

--- a/src/main/webapp/static/com/atomgraph/client/xsl/functions.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/functions.xsl
@@ -89,14 +89,32 @@ exclude-result-prefixes="#all"
         </xsl:message>
     </xsl:function>
     
-    <!-- position of a value's language in $ac:langs, used as a sort key so each property leads with the reader's language.
+    <!-- the languages the reader accepts, most preferred first, reduced to primary subtags and deduped.
+
+         Server-side that is the Accept-Language list the writer supplies; client-side LinkedDataHub overrides this whole
+         function with one that reads the browser's own list, because Web-Client carries no browser dependencies. The two
+         bodies are guarded by use-when so exactly one exists in any compilation - neither engine ever sees the other's.
+
+         Normalising here rather than at each declaration is what keeps the two engines agreeing: primary subtags because
+         fn:lang() prefix-matches, so 'es' reaches a label tagged es-ES while 'es-ES' would not reach one tagged es; deduped
+         because a browser sending es-ES,es yields the same subtag twice; and 'en' when the reader expressed no preference,
+         which is the same floor the negotiation applies server-side. -->
+    <xsl:function name="ac:langs" as="xs:string*" use-when="system-property('xsl:product-name') = 'SAXON'">
+        <xsl:variable name="langs" select="distinct-values(for $lang in $ac:langs return tokenize($lang, '-')[1])[not(. = ('', '*'))]" as="xs:string*"/>
+
+        <xsl:sequence select="if (exists($langs)) then $langs else 'en'"/>
+    </xsl:function>
+
+    <!-- position of a value's language in the accepted list, used as a sort key so each property leads with the reader's language.
          Values in a language the reader does not accept, and untagged values, rank last and so sort after the accepted ones
          - they are ordered, never withheld. Takes the node explicitly: the one-argument fn:lang tests the context item, and
          a rank computed over a range of integers has no node to test. -->
     <xsl:function name="ac:lang-rank" as="xs:integer">
         <xsl:param name="value" as="element()"/>
 
-        <xsl:sequence select="((for $i in 1 to count($ac:langs) return if (lang($ac:langs[$i], $value)) then $i else ())[1], count($ac:langs) + 1)[1]"/>
+        <xsl:variable name="langs" select="ac:langs()" as="xs:string*"/>
+
+        <xsl:sequence select="((for $i in 1 to count($langs) return if (lang($langs[$i], $value)) then $i else ())[1], count($langs) + 1)[1]"/>
     </xsl:function>
 
     <xsl:function name="ac:label" as="xs:string?">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/dc.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/dc.xsl
@@ -28,16 +28,16 @@ xmlns:rdf="&rdf;"
 xmlns:dc="&dc;"
 exclude-result-prefixes="#all">
 
-    <xsl:template match="*[dc:title[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return dc:title[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[dc:title[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return dc:title[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[dc:title/text()]" mode="ac:label">
         <xsl:sequence select="(dc:title[not(@xml:lang)], dc:title)[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[dc:description[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return dc:description[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[dc:description[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return dc:description[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[dc:description/text()]" mode="ac:description">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/dct.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/dct.xsl
@@ -28,16 +28,16 @@ xmlns:rdf="&rdf;"
 xmlns:dct="&dct;"
 exclude-result-prefixes="#all">
 
-    <xsl:template match="*[dct:title[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return dct:title[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[dct:title[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return dct:title[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[dct:title/text()]" mode="ac:label">
         <xsl:sequence select="(dct:title[not(@xml:lang)], dct:title)[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[dct:description[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return dct:description[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[dct:description[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return dct:description[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[dct:description/text()]" mode="ac:description">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
@@ -131,6 +131,12 @@ exclude-result-prefixes="#all">
 
     <xsl:template match="node()" mode="ac:image"/>
 
+    <!-- LANGUAGE TAG -->
+
+    <!-- the tag a value carries, shown wherever a skin renders several languages side by side. Nothing generic to show:
+         a skin that has a badge for it overrides this, the built-in attribute rule would otherwise leak the bare code -->
+    <xsl:template match="@xml:lang" mode="ac:lang-tag"/>
+
     <!-- DEFINITIONS -->
     
     <xsl:template match="*[@rdf:about or @rdf:nodeID]/*" mode="xhtml:DefinitionTerm">
@@ -473,27 +479,38 @@ exclude-result-prefixes="#all">
         <xsl:variable name="property-uri" select="concat(namespace-uri(), local-name())" as="xs:string"/>
 
         <td>
-            <xsl:for-each select="../*[concat(namespace-uri(), local-name()) = $property-uri]">
-                <xsl:sort select="ac:lang-rank(.)"/>
-
-                <!-- each value declares its own language rather than inheriting the document's, since the cell now holds
-                     several at once and the document default is wrong for all but one of them -->
-                <span>
-                    <xsl:choose>
-                        <xsl:when test="@xml:lang">
-                            <xsl:attribute name="lang" select="@xml:lang"/>
-                        </xsl:when>
-                        <!-- an untagged literal makes no language claim, which HTML spells lang="". A typed value is not
-                             prose and inherits, so a number or a date is read out in the reader's own language -->
-                        <xsl:when test="text() and (not(@rdf:datatype) or @rdf:datatype = '&xsd;string')">
-                            <xsl:attribute name="lang" select="''"/>
-                        </xsl:when>
-                    </xsl:choose>
-
-                    <xsl:apply-templates select="node() | @rdf:resource | @rdf:nodeID"/>
-                </span>
-            </xsl:for-each>
+            <!-- the values stack rather than run together, and the stack is what carries the height: a cell cannot cap its
+                 own, so a property with many values has to be bounded by a container the cell holds -->
+            <div class="values">
+                <xsl:apply-templates select="../*[concat(namespace-uri(), local-name()) = $property-uri]" mode="xhtml:TableDataCellValue">
+                    <xsl:sort select="ac:lang-rank(.)"/>
+                </xsl:apply-templates>
+            </div>
         </td>
+    </xsl:template>
+
+    <!-- one block per statement, so the values stack apart instead of running into each other. The statement is the unit,
+         not the node under it: an XHTML literal is one value however many elements it is written with -->
+    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*" mode="xhtml:TableDataCellValue">
+        <div class="value">
+            <!-- an untagged literal makes no language claim, which HTML spells lang="". A typed value is not prose and
+                 inherits, so a number or a date is read out in the reader's own language -->
+            <xsl:if test="text() and (not(@rdf:datatype) or @rdf:datatype = '&xsd;string')">
+                <xsl:attribute name="lang" select="''"/>
+            </xsl:if>
+
+            <xsl:apply-templates select="node() | @rdf:resource | @rdf:nodeID"/>
+        </div>
+    </xsl:template>
+
+    <!-- each value declares its own language rather than inheriting the document's, since the cell holds several at once
+         and the document default is wrong for all but one of them -->
+    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*[@xml:lang]" mode="xhtml:TableDataCellValue" priority="1">
+        <div class="value" lang="{@xml:lang}">
+            <xsl:apply-templates select="node() | @rdf:resource | @rdf:nodeID"/>
+
+            <xsl:apply-templates select="@xml:lang" mode="ac:lang-tag"/>
+        </div>
     </xsl:template>
 
     <xsl:template match="srx:sparql" mode="xhtml:Table">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
@@ -374,7 +374,7 @@ exclude-result-prefixes="#all">
                 <xsl:attribute name="class" select="$class"/>
             </xsl:if>
             
-            <xsl:sequence select="format-date(., '[D] [MNn] [Y]', $ac:lang, (), ())"/>
+            <xsl:sequence select="format-date(., '[D] [MNn] [Y]', ac:langs()[1], (), ())"/>
         </span>
     </xsl:template>
 
@@ -397,7 +397,7 @@ exclude-result-prefixes="#all">
 
             <!-- http://www.w3.org/TR/xslt20/#date-time-examples -->
             <!-- http://en.wikipedia.org/wiki/Date_format_by_country -->
-            <xsl:sequence select="format-dateTime(adjust-dateTime-to-timezone(., $timezone), '[D] [MNn] [Y] [H01]:[m01]', $ac:lang, (), ())"/>
+            <xsl:sequence select="format-dateTime(adjust-dateTime-to-timezone(., $timezone), '[D] [MNn] [Y] [H01]:[m01]', ac:langs()[1], (), ())"/>
         </span>
     </xsl:template>
 

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
@@ -46,10 +46,6 @@ xmlns:url="&java;java.net.URLDecoder"
 xmlns:xhtml="http://www.w3.org/1999/xhtml"
 exclude-result-prefixes="#all">
 
-    <!-- ordered language preference list; the writer passes Accept-Language, client-side stylesheets override with the browser's list -->
-    <xsl:param name="ac:langs" select="'en'" as="xs:string*"/>
-    <xsl:param name="ac:lang" select="($ac:langs[1], 'en')[1]" as="xs:string"/>
-
     <xsl:key name="resources" match="*[*][@rdf:about] | *[*][@rdf:nodeID]" use="@rdf:about | @rdf:nodeID"/>
 
     <!-- LABEL -->
@@ -194,8 +190,19 @@ exclude-result-prefixes="#all">
             <xsl:if test="$target">
                 <xsl:attribute name="target" select="$target"/>
             </xsl:if>
-            
-            <xsl:apply-templates select=".." mode="ac:label"/>
+
+            <!-- the label was chosen from whichever language the reader accepts, so the link says which one it ended up
+                 in. A label built as a computed string has no literal behind it and inherits instead -->
+            <xsl:variable name="label" as="item()*">
+                <xsl:apply-templates select=".." mode="ac:label"/>
+            </xsl:variable>
+            <xsl:variable name="label-lang" select="$label[1][. instance of node()]/../@xml:lang" as="attribute()?"/>
+
+            <xsl:if test="$label-lang">
+                <xsl:attribute name="lang" select="$label-lang"/>
+            </xsl:if>
+
+            <xsl:sequence select="$label"/>
         </a>
     </xsl:template>
     
@@ -212,7 +219,18 @@ exclude-result-prefixes="#all">
                 <xsl:attribute name="class" select="$class"/>
             </xsl:if>
 
-            <xsl:apply-templates select=".." mode="ac:label"/>
+            <!-- the label was chosen from whichever language the reader accepts, so the link says which one it ended up
+                 in. A label built as a computed string has no literal behind it and inherits instead -->
+            <xsl:variable name="label" as="item()*">
+                <xsl:apply-templates select=".." mode="ac:label"/>
+            </xsl:variable>
+            <xsl:variable name="label-lang" select="$label[1][. instance of node()]/../@xml:lang" as="attribute()?"/>
+
+            <xsl:if test="$label-lang">
+                <xsl:attribute name="lang" select="$label-lang"/>
+            </xsl:if>
+
+            <xsl:sequence select="$label"/>
         </span>
     </xsl:template>
 
@@ -299,18 +317,6 @@ exclude-result-prefixes="#all">
     <xsl:template match="text()">
         <xsl:sequence select="."/>
     </xsl:template>
-
-    <!-- show literals that match $ldt:lang, if any -->
-    <!-- 
-    <xsl:template match="text()[$ldt:lang][../@xml:lang and lang($ldt:lang, ..)]" priority="1">
-        <xsl:next-match/>
-    </xsl:template>
-    -->
-
-    <!-- suppress literals that have @xml:lang but do not match $ldt:lang, if they have siblings that do match -->
-    <!--
-    <xsl:template match="text()[$ldt:lang][../@xml:lang and not(lang($ldt:lang, ..))][../preceding-sibling::*[namespace-uri() || local-name() = namespace-uri(current()/..) || local-name(current()/..)][lang($ldt:lang)] or ../following-sibling::*[namespace-uri() || local-name() = namespace-uri(current()/..) || local-name(current()/..)][lang($ldt:lang)]]" priority="1"/>
-    -->
 
     <xsl:template match="text()[../@rdf:datatype] | srx:literal[@datatype]">
         <xsl:param name="id" as="xs:string?"/>
@@ -445,19 +451,37 @@ exclude-result-prefixes="#all">
         </th>
     </xsl:template>
     
+    <!-- every value of the property beyond the first is folded into the cell the first one opens -->
     <xsl:template match="*[@rdf:about or @rdf:nodeID]/*" mode="xhtml:TableDataCell"/>
 
-    <!-- apply properties that match lang() -->
-    <xsl:template match="*[$ac:lang][@rdf:about or @rdf:nodeID]/*[lang($ac:lang)]" mode="xhtml:TableDataCell" priority="1">
+    <!-- the header fixes the column count, so a property gets one cell however many values it has, and they share it.
+         Ordering them by the reader's languages puts the one they read first and leaves the rest reachable: a reader whose
+         language the data lacks used to be shown the first value in document order, and every other reader was shown one
+         value with no sign that the others existed -->
+    <xsl:template match="*[@rdf:about or @rdf:nodeID]/*[not(preceding-sibling::*[concat(namespace-uri(), local-name()) = concat(namespace-uri(current()), local-name(current()))])]" mode="xhtml:TableDataCell" priority="1">
+        <xsl:variable name="property-uri" select="concat(namespace-uri(), local-name())" as="xs:string"/>
+
         <td>
-            <xsl:apply-templates select="node() | @rdf:resource | @rdf:nodeID"/>
-        </td>
-    </xsl:template>
-    
-    <!-- apply the first one in the group if there's no lang() match -->
-    <xsl:template match="*[$ac:lang][@rdf:about or @rdf:nodeID]/*[not(../*[concat(namespace-uri(), local-name()) = concat(namespace-uri(current()), local-name(current()))][lang($ac:lang)])][not(preceding-sibling::*[concat(namespace-uri(), local-name()) = concat(namespace-uri(current()), local-name(current()))])]" mode="xhtml:TableDataCell" priority="1">
-        <td>
-            <xsl:apply-templates select="node() | @rdf:resource | @rdf:nodeID"/>
+            <xsl:for-each select="../*[concat(namespace-uri(), local-name()) = $property-uri]">
+                <xsl:sort select="ac:lang-rank(.)"/>
+
+                <!-- each value declares its own language rather than inheriting the document's, since the cell now holds
+                     several at once and the document default is wrong for all but one of them -->
+                <span>
+                    <xsl:choose>
+                        <xsl:when test="@xml:lang">
+                            <xsl:attribute name="lang" select="@xml:lang"/>
+                        </xsl:when>
+                        <!-- an untagged literal makes no language claim, which HTML spells lang="". A typed value is not
+                             prose and inherits, so a number or a date is read out in the reader's own language -->
+                        <xsl:when test="text() and (not(@rdf:datatype) or @rdf:datatype = '&xsd;string')">
+                            <xsl:attribute name="lang" select="''"/>
+                        </xsl:when>
+                    </xsl:choose>
+
+                    <xsl:apply-templates select="node() | @rdf:resource | @rdf:nodeID"/>
+                </span>
+            </xsl:for-each>
         </td>
     </xsl:template>
 

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/default.xsl
@@ -278,10 +278,21 @@ exclude-result-prefixes="#all">
             <xsl:if test="$target">
                 <xsl:attribute name="target" select="$target"/>
             </xsl:if>
-            
-            <xsl:value-of>
+
+            <!-- the label was picked from whichever language the reader accepts, so the link says which one it ended up in.
+                 Bound as nodes rather than wrapped in xsl:value-of, which would atomize the literal and discard the tag
+                 before it could be read. A label built as a computed string - a fragment identifier, a decoded path segment
+                 - has no literal behind it and inherits instead -->
+            <xsl:variable name="label" as="item()*">
                 <xsl:apply-templates select="." mode="ac:object-label"/>
-            </xsl:value-of>
+            </xsl:variable>
+            <xsl:variable name="label-lang" select="$label[1][. instance of node()]/../@xml:lang" as="attribute()?"/>
+
+            <xsl:if test="$label-lang">
+                <xsl:attribute name="lang" select="$label-lang"/>
+            </xsl:if>
+
+            <xsl:value-of select="$label"/>
         </a>
     </xsl:template>
 

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/doap.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/doap.xsl
@@ -28,16 +28,16 @@ xmlns:rdf="&rdf;"
 xmlns:doap="&doap;"
 exclude-result-prefixes="#all">
     
-    <xsl:template match="*[doap:name[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return doap:name[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[doap:name[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return doap:name[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[doap:name/text()]" mode="ac:label">
         <xsl:sequence select="(doap:name[not(@xml:lang)], doap:name)[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[doap:description[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return doap:description[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[doap:description[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return doap:description[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[doap:description/text()]" mode="ac:description">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/foaf.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/foaf.xsl
@@ -84,8 +84,8 @@ exclude-result-prefixes="#all">
         <xsl:sequence select="foaf:nick/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[foaf:name[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="6">
-        <xsl:sequence select="(for $lang in $ac:langs return foaf:name[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[foaf:name[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="6">
+        <xsl:sequence select="(for $lang in ac:langs() return foaf:name[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[foaf:name/text()]" mode="ac:label" priority="4">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/rdfs.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/rdfs.xsl
@@ -28,16 +28,16 @@ xmlns:rdf="&rdf;"
 xmlns:rdfs="&rdfs;"
 exclude-result-prefixes="#all">
 
-    <xsl:template match="*[rdfs:label[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return rdfs:label[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[rdfs:label[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return rdfs:label[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[rdfs:label/text()]" mode="ac:label">
         <xsl:sequence select="(rdfs:label[not(@xml:lang)], rdfs:label)[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[rdfs:comment[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return rdfs:comment[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[rdfs:comment[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return rdfs:comment[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[rdfs:comment/text()]" mode="ac:description">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/schema.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/schema.xsl
@@ -30,12 +30,12 @@ xmlns:schema1="&schema1;"
 xmlns:schema2="&schema2;"
 exclude-result-prefixes="#all">
 
-    <xsl:template match="*[schema1:name[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return schema1:name[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[schema1:name[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return schema1:name[lang($lang)])[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[schema2:name[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return schema2:name[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[schema2:name[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return schema2:name[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[schema1:name/text()]" mode="ac:label">
@@ -46,12 +46,12 @@ exclude-result-prefixes="#all">
         <xsl:sequence select="(schema2:name[not(@xml:lang)], schema2:name)[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[schema1:description[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return schema1:description[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[schema1:description[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return schema1:description[lang($lang)])[1]/text()"/>
     </xsl:template>
 
-    <xsl:template match="*[schema2:description[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return schema2:description[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[schema2:description[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:description" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return schema2:description[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[schema1:description/text()]" mode="ac:description">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/sioc.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/sioc.xsl
@@ -28,8 +28,8 @@ xmlns:rdf="&rdf;"
 xmlns:sioc="&sioc;"
 exclude-result-prefixes="#all">
     
-    <xsl:template match="*[sioc:name[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return sioc:name[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[sioc:name[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return sioc:name[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[sioc:name/text()]" mode="ac:label">

--- a/src/main/webapp/static/com/atomgraph/client/xsl/imports/skos.xsl
+++ b/src/main/webapp/static/com/atomgraph/client/xsl/imports/skos.xsl
@@ -28,8 +28,8 @@ xmlns:rdf="&rdf;"
 xmlns:skos="&skos;"
 exclude-result-prefixes="#all">
 
-    <xsl:template match="*[skos:prefLabel[some $lang in $ac:langs satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
-        <xsl:sequence select="(for $lang in $ac:langs return skos:prefLabel[lang($lang)])[1]/text()"/>
+    <xsl:template match="*[skos:prefLabel[some $lang in ac:langs() satisfies lang($lang)]/text()]" mode="ac:label" priority="1">
+        <xsl:sequence select="(for $lang in ac:langs() return skos:prefLabel[lang($lang)])[1]/text()"/>
     </xsl:template>
 
     <xsl:template match="*[skos:prefLabel/text()]" mode="ac:label">


### PR DESCRIPTION
Follow-up to #89/#90. Those made label lookup negotiate over the reader's ordered
language preferences; this branch makes the rendered page *say* which language it
ended up in, and stops the negotiation from silently discarding the values it did
not pick.

## What changes

**`$ac:langs` is a function, not a parameter.** `ac:langs()` is declared once in
`functions.xsl` and answered differently by Saxon and Saxon-JS via `use-when`, so
the server reads `Accept-Language` and the browser reads `navigator.languages`
without either side re-declaring the state. `$ldt:lang` and its `LDT.java` term go
with it — the last of the language state that lived in two places.

**The page declares the language it is written in**, rather than the one that was
asked for, and publishes the shortest tag the bundle justifies rather than the key
it happens to be stored under.

**Every rendered value carries its own language.** A label chosen from one of
several languages is marked with the tag it was chosen in — on the anchor and the
span that emit it, read off the literal `ac:label` mode picked, with no caller
passing it in. A label computed from a URI has no literal behind it and inherits.
An untagged literal gets `lang=""`, HTML's spelling of RDF's absent tag; a typed
value is not prose and inherits, so a number or a date is read out in whatever
language the reader is in. This is WCAG 3.1.2, and it keeps the extracted RDFa
faithful.

**A table cell holds every value its property has.** A cell used to render the one
value matching the reader's language, or the first in document order when none
matched, and drop the rest — so a reader whose language the data lacks saw an
arbitrary value and everyone else saw one value with no sign the others existed.
The header fixes the column count, so the values now share the one cell the first
one opens, ordered by `ac:lang-rank()`.

**…and lays them out instead of merely emitting them.** The first cut wrapped each
value in a bare span with nothing between them, which reads fine for a title in
three languages and not at all for eight object references: they ran together into
one unbroken line, wrapping mid-token. Each value is now a block of its own inside
a container the cell holds — a `td` cannot bound its own height, so the container
is what a skin caps, and a property with fifty values scrolls rather than setting
the row height for the whole table. Nothing is dropped from the DOM.

The layout is a mode, `xhtml:TableDataCellValue`, so a skin overrides a cell's
values the way it already overrides a property list's. It matches the statement
rather than the nodes beneath it, so an XHTML literal stays one value however many
elements it is written with.

**The language badge is written once.** It existed inline in the property list and
was about to be copied into the table cell; it moves to an `ac:lang-tag` mode over
`@xml:lang`, applied from wherever values are laid out, so the two cannot drift.
The generic layer answers it with nothing, the Bootstrap layer with its label, and
a downstream skin with whatever it uses.

## Verification

No automated coverage for rendering; checked by eye against LinkedDataHub's
Northwind Traders demo — a container table with a high-arity object property, a
resource description with multi-language titles, under both the server render and
the Saxon-JS one, which share these stylesheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YxhcqMPK1kZR1pxxJqoge
